### PR TITLE
Add CLI benchmarks in multiple languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
-# banchmark-langs
+# Benchmark Languages
+
+This repository provides small CLI programs in multiple languages that
+perform the same task: summing numbers while measuring execution time.
+They are intended for comparing runtime performance on Linux/WSL.
+
+## Languages Included
+
+- C
+- C++
+- Rust
+- Go
+- Python
+- JavaScript (Node.js)
+- Java
+
+## Installing Compilers/Interpreters
+
+On Ubuntu you can install the required tools with:
+
+```bash
+sudo apt-get update
+sudo apt-get install build-essential golang rustc cargo python3 nodejs default-jdk
+```
+
+## Build and Run
+
+### C
+
+```bash
+gcc -O2 c/time_test.c -o c/time_test
+./c/time_test 10000000
+```
+
+### C++
+
+```bash
+g++ -O2 cpp/time_test.cpp -o cpp/time_test
+./cpp/time_test 10000000
+```
+
+### Rust
+
+```bash
+cd rust
+cargo build --release
+./target/release/rust_app 10000000
+```
+
+### Go
+
+```bash
+go build -o go/time_test go/main.go
+./go/time_test 10000000
+```
+
+### Python
+
+```bash
+python3 python/main.py 10000000
+```
+
+### Node.js
+
+```bash
+node node/main.js 10000000
+```
+
+### Java
+
+```bash
+javac java/TimeTest.java
+java -cp java TimeTest 10000000
+```
+
+You can change the numeric argument to adjust the workload for your benchmark.

--- a/c/time_test.c
+++ b/c/time_test.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+int main(int argc, char *argv[]) {
+    long long n = 10000000;
+    if (argc > 1) {
+        n = atoll(argv[1]);
+    }
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    long long sum = 0;
+    for (long long i = 0; i < n; ++i) {
+        sum += i;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    double elapsed = (end.tv_sec - start.tv_sec) + (end.tv_nsec - start.tv_nsec) / 1e9;
+    printf("sum=%lld time=%f\n", sum, elapsed);
+    return 0;
+}

--- a/cpp/time_test.cpp
+++ b/cpp/time_test.cpp
@@ -1,0 +1,18 @@
+#include <chrono>
+#include <iostream>
+
+int main(int argc, char* argv[]) {
+    long long n = 10000000;
+    if (argc > 1) {
+        n = std::stoll(argv[1]);
+    }
+    auto start = std::chrono::steady_clock::now();
+    long long sum = 0;
+    for (long long i = 0; i < n; ++i) {
+        sum += i;
+    }
+    auto end = std::chrono::steady_clock::now();
+    std::chrono::duration<double> elapsed = end - start;
+    std::cout << "sum=" << sum << " time=" << elapsed.count() << std::endl;
+    return 0;
+}

--- a/go/main.go
+++ b/go/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+    "fmt"
+    "os"
+    "strconv"
+    "time"
+)
+
+func main() {
+    n := int64(10000000)
+    if len(os.Args) > 1 {
+        if val, err := strconv.ParseInt(os.Args[1], 10, 64); err == nil {
+            n = val
+        }
+    }
+    start := time.Now()
+    sum := int64(0)
+    for i := int64(0); i < n; i++ {
+        sum += i
+    }
+    elapsed := time.Since(start).Seconds()
+    fmt.Printf("sum=%d time=%f\n", sum, elapsed)
+}

--- a/java/TimeTest.java
+++ b/java/TimeTest.java
@@ -1,0 +1,17 @@
+public class TimeTest {
+    public static void main(String[] args) {
+        long n = 10000000;
+        if (args.length > 0) {
+            try {
+                n = Long.parseLong(args[0]);
+            } catch (NumberFormatException ignored) {}
+        }
+        long start = System.nanoTime();
+        long sum = 0;
+        for (long i = 0; i < n; i++) {
+            sum += i;
+        }
+        double elapsed = (System.nanoTime() - start) / 1_000_000_000.0;
+        System.out.println("sum=" + sum + " time=" + elapsed);
+    }
+}

--- a/node/main.js
+++ b/node/main.js
@@ -1,0 +1,9 @@
+const n = process.argv[2] ? parseInt(process.argv[2], 10) : 10000000;
+const start = process.hrtime.bigint();
+let sum = 0;
+for (let i = 0; i < n; i++) {
+  sum += i;
+}
+const end = process.hrtime.bigint();
+const elapsed = Number(end - start) / 1e9;
+console.log(`sum=${sum} time=${elapsed}`);

--- a/python/main.py
+++ b/python/main.py
@@ -1,0 +1,8 @@
+import sys
+import time
+
+n = int(sys.argv[1]) if len(sys.argv) > 1 else 10_000_000
+start = time.perf_counter()
+s = sum(range(n))
+elapsed = time.perf_counter() - start
+print(f"sum={s} time={elapsed}")

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "rust_app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,0 +1,18 @@
+use std::env;
+use std::time::Instant;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let n: i64 = if args.len() > 1 {
+        args[1].parse().unwrap_or(10_000_000)
+    } else {
+        10_000_000
+    };
+    let start = Instant::now();
+    let mut sum: i64 = 0;
+    for i in 0..n {
+        sum += i;
+    }
+    let duration = start.elapsed();
+    println!("sum={} time={:.6}", sum, duration.as_secs_f64());
+}


### PR DESCRIPTION
## Summary
- add simple benchmark programs in C, C++, Rust, Go, Python, Node.js and Java
- provide instructions in README for building and running each language implementation

## Testing
- `gcc -O2 c/time_test.c -o /tmp/time_test_c`
- `/tmp/time_test_c 1000`
- `g++ -O2 cpp/time_test.cpp -o /tmp/time_test_cpp`
- `/tmp/time_test_cpp 1000`
- `cd rust && cargo build --release`
- `./target/release/rust_app 1000`
- `go build -o /tmp/time_test_go go/main.go`
- `/tmp/time_test_go 1000`
- `node node/main.js 1000`
- `python3 python/main.py 1000`
- `javac java/TimeTest.java`
- `java -cp java TimeTest 1000`


------
https://chatgpt.com/codex/tasks/task_e_686671d570c8832dace353332abb788e