### PR TITLE
Fix rust loop type

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -3,13 +3,13 @@ use std::time::Instant;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let n: i64 = if args.len() > 1 {
+    let n: usize = if args.len() > 1 {
         args[1].parse().unwrap_or(10_000_000)
     } else {
         10_000_000
     };
     let start = Instant::now();
-    let mut sum: i64 = 0;
+    let mut sum: usize = 0;
     for i in 0..n {
         sum += i;
     }


### PR DESCRIPTION
## Summary
- use `usize` for the loop counter in Rust example
- keep the running sum in a `usize`

## Testing
- `cargo build --release`

------
https://chatgpt.com/codex/tasks/task_e_68667569f178832db5993af1d6e3e592