### PR TITLE
Add elapsed time output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,90 @@
-# banchmark-langs
+# Benchmark Languages
+
+This repository provides small CLI programs in multiple languages that
+perform an identical, moderately complex workload while measuring both CPU
+cycles and wall-clock time consumed.  The programs manipulate integers and strings in a loop so
+the compiler cannot optimise the entire computation away.  They are intended
+for comparing performance across languages on Linux/WSL.
+
+## Languages Included
+
+- C
+- C++
+- Rust
+- Go
+- Python
+- JavaScript (Node.js)
+- Java
+
+## Installing Compilers/Interpreters
+
+On Ubuntu you can install the required tools with:
+
+```bash
+sudo apt-get update
+sudo apt-get install build-essential golang rustc cargo python3 nodejs default-jdk
+```
+
+## Build and Run
+
+### C
+
+```bash
+gcc -O2 c/time_test.c -o c/time_test
+./c/time_test 1000000
+```
+
+### C++
+
+```bash
+g++ -O2 cpp/time_test.cpp -o cpp/time_test
+./cpp/time_test 1000000
+```
+
+### Rust
+
+```bash
+cd rust
+cargo build --release
+./target/release/rust_app 1000000
+```
+
+### Go
+
+```bash
+go build -o go/time_test go/main.go
+./go/time_test 1000000
+```
+
+### Python
+
+```bash
+python3 python/main.py 1000000
+```
+
+### Node.js
+
+```bash
+node node/main.js 1000000
+```
+
+### Java
+
+```bash
+javac java/TimeTest.java
+java -cp java TimeTest 1000000
+```
+
+You can change the numeric argument to adjust the workload for your benchmark.
+
+### Run all benchmarks
+
+The helper script `run_benchmarks.py` builds and runs each implementation in
+sequence. Provide the desired iteration count as an argument:
+
+```bash
+python3 run_benchmarks.py 1000000
+```
+
+The script prints the output from each language and a table summarizing the
+cycle counts and execution times.

--- a/c/time_test.c
+++ b/c/time_test.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <x86intrin.h>
+#include <time.h>
+
+int main(int argc, char *argv[]) {
+    long long n = 1000000;
+    if (argc > 1) {
+        n = atoll(argv[1]);
+    }
+    struct timespec ts_start, ts_end;
+    clock_gettime(CLOCK_MONOTONIC, &ts_start);
+    unsigned long long start = __rdtsc();
+    long long sum_len = 0;
+    long long dummy = 0;
+    char buf[32];
+    for (long long i = 0; i < n; ++i) {
+        long long x = i * 3 + 7;
+        x = (x ^ (x << 2)) + (x >> 3);
+        snprintf(buf, sizeof(buf), "%lld", x);
+        sum_len += strlen(buf);
+        dummy += x;
+    }
+    unsigned long long end = __rdtsc();
+    clock_gettime(CLOCK_MONOTONIC, &ts_end);
+    double elapsed = (ts_end.tv_sec - ts_start.tv_sec) +
+                     (ts_end.tv_nsec - ts_start.tv_nsec) / 1e9;
+    printf("sum=%lld dummy=%lld cycles=%llu time=%f\n",
+           sum_len, dummy, end - start, elapsed);
+    return 0;
+}

--- a/cpp/time_test.cpp
+++ b/cpp/time_test.cpp
@@ -1,0 +1,28 @@
+#include <chrono>
+#include <iostream>
+#include <x86intrin.h>
+
+int main(int argc, char* argv[]) {
+    long long n = 1000000;
+    if (argc > 1) {
+        n = std::stoll(argv[1]);
+    }
+    auto wall_start = std::chrono::high_resolution_clock::now();
+    unsigned long long start = __rdtsc();
+    long long sum_len = 0;
+    long long dummy = 0;
+    for (long long i = 0; i < n; ++i) {
+        long long x = i * 3 + 7;
+        x = (x ^ (x << 2)) + (x >> 3);
+        std::string s = std::to_string(x);
+        sum_len += s.size();
+        dummy += x;
+    }
+    unsigned long long end = __rdtsc();
+    auto wall_end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = wall_end - wall_start;
+    std::cout << "sum=" << sum_len << " dummy=" << dummy
+              << " cycles=" << end - start
+              << " time=" << elapsed.count() << std::endl;
+    return 0;
+}

--- a/go/main.go
+++ b/go/main.go
@@ -1,0 +1,37 @@
+package main
+
+/*
+#include <x86intrin.h>
+unsigned long long read_cycles() { return __rdtsc(); }
+*/
+import "C"
+
+import (
+    "fmt"
+    "os"
+    "strconv"
+    "time"
+)
+
+func main() {
+    n := int64(1000000)
+    if len(os.Args) > 1 {
+        if val, err := strconv.ParseInt(os.Args[1], 10, 64); err == nil {
+            n = val
+        }
+    }
+    startWall := time.Now()
+    start := C.read_cycles()
+    sumLen := int64(0)
+    dummy := int64(0)
+    for i := int64(0); i < n; i++ {
+        x := i*3 + 7
+        x = (x ^ (x << 2)) + (x >> 3)
+        s := fmt.Sprintf("%d", x)
+        sumLen += int64(len(s))
+        dummy += x
+    }
+    end := C.read_cycles()
+    elapsed := time.Since(startWall).Seconds()
+    fmt.Printf("sum=%d dummy=%d cycles=%d time=%f\n", sumLen, dummy, end-start, elapsed)
+}

--- a/java/TimeTest.java
+++ b/java/TimeTest.java
@@ -1,0 +1,44 @@
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+
+public class TimeTest {
+
+    private static long cpuFreq() {
+        try (BufferedReader br = new BufferedReader(new FileReader("/proc/cpuinfo"))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.startsWith("cpu MHz")) {
+                    String[] parts = line.split(":");
+                    return (long) (Double.parseDouble(parts[1].trim()) * 1_000_000L);
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return 1_000_000_000L;
+    }
+
+    public static void main(String[] args) {
+        long n = 1_000_000;
+        if (args.length > 0) {
+            try {
+                n = Long.parseLong(args[0]);
+            } catch (NumberFormatException ignored) {}
+        }
+        long freq = cpuFreq();
+        long start = System.nanoTime();
+        long sumLen = 0;
+        long dummy = 0;
+        for (long i = 0; i < n; i++) {
+            long x = i * 3 + 7;
+            x = (x ^ (x << 2)) + (x >> 3);
+            String s = Long.toString(x);
+            sumLen += s.length();
+            dummy += x;
+        }
+        long elapsedNs = System.nanoTime() - start;
+        long cycles = (elapsedNs * freq) / 1_000_000_000L;
+        double timeSec = elapsedNs / 1_000_000_000.0;
+        System.out.println("sum=" + sumLen + " dummy=" + dummy + " cycles=" + cycles + " time=" + timeSec);
+    }
+}

--- a/node/main.js
+++ b/node/main.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+
+function cpuFreq() {
+  try {
+    const txt = fs.readFileSync('/proc/cpuinfo', 'utf8');
+    const m = txt.match(/cpu MHz\s+:\s+([0-9.]+)/);
+    if (m) return parseFloat(m[1]) * 1e6;
+  } catch (e) {}
+  return 1e9;
+}
+
+const n = process.argv[2] ? parseInt(process.argv[2], 10) : 1000000;
+const freq = cpuFreq();
+const start = process.hrtime.bigint();
+let sumLen = 0;
+let dummy = 0;
+for (let i = 0; i < n; i++) {
+  let x = i * 3 + 7;
+  x = (x ^ (x << 2)) + (x >> 3);
+  const s = String(x);
+  sumLen += s.length;
+  dummy += x;
+}
+const elapsedNs = process.hrtime.bigint() - start;
+const cycles = Math.round(Number(elapsedNs) * freq / 1e9);
+const timeSec = Number(elapsedNs) / 1e9;
+console.log(`sum=${sumLen} dummy=${dummy} cycles=${cycles} time=${timeSec}`);

--- a/python/main.py
+++ b/python/main.py
@@ -1,0 +1,29 @@
+import sys
+import time
+
+
+def cpu_freq():
+    try:
+        with open('/proc/cpuinfo') as f:
+            for line in f:
+                if line.startswith('cpu MHz'):
+                    return float(line.split(':')[1]) * 1e6
+    except FileNotFoundError:
+        pass
+    return 1e9
+
+
+n = int(sys.argv[1]) if len(sys.argv) > 1 else 1_000_000
+freq = cpu_freq()
+start = time.perf_counter()
+sum_len = 0
+dummy = 0
+for i in range(n):
+    x = i * 3 + 7
+    x = (x ^ (x << 2)) + (x >> 3)
+    s = str(x)
+    sum_len += len(s)
+    dummy += x
+elapsed = time.perf_counter() - start
+cycles = int(elapsed * freq)
+print(f"sum={sum_len} dummy={dummy} cycles={cycles} time={elapsed}")

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import re
+from pathlib import Path
+import os
+
+ROOT = Path(__file__).resolve().parent
+
+# compile all languages
+
+def run(cmd, cwd=None, env=None):
+    result = subprocess.run(cmd, shell=True, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    if result.stdout:
+        print(result.stdout)
+    return result
+
+def build_all():
+    run("gcc -O2 time_test.c -o time_test", cwd=ROOT / 'c')
+    run("g++ -O2 time_test.cpp -o time_test", cwd=ROOT / 'cpp')
+    run("cargo build --release", cwd=ROOT / 'rust')
+    env = os.environ.copy()
+    env['CGO_ENABLED'] = '1'
+    run("go build -o time_test main.go", cwd=ROOT / 'go', env=env)
+    run("javac TimeTest.java", cwd=ROOT / 'java')
+
+
+def capture_output(cmd, cwd=None):
+    result = subprocess.run(cmd, shell=True, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    return result.stdout.strip()
+
+
+def run_programs(n):
+    results = {}
+    outputs = {}
+    outputs['C'] = capture_output(f"./time_test {n}", cwd=ROOT / 'c')
+    outputs['C++'] = capture_output(f"./time_test {n}", cwd=ROOT / 'cpp')
+    outputs['Rust'] = capture_output(f"./target/release/rust_app {n}", cwd=ROOT / 'rust')
+    outputs['Go'] = capture_output(f"./time_test {n}", cwd=ROOT / 'go')
+    outputs['Python'] = capture_output(f"python3 main.py {n}", cwd=ROOT / 'python')
+    outputs['Node'] = capture_output(f"node main.js {n}", cwd=ROOT / 'node')
+    outputs['Java'] = capture_output(f"java TimeTest {n}", cwd=ROOT / 'java')
+
+    for lang, out in outputs.items():
+        m_cycles = re.search(r'cycles=([0-9]+)', out)
+        m_time = re.search(r'time=([0-9.eE+-]+)', out)
+        results[lang] = {
+            'cycles': m_cycles.group(1) if m_cycles else 'N/A',
+            'time': m_time.group(1) if m_time else 'N/A'
+        }
+    return results, outputs
+
+
+def print_table(results):
+    print("\nResults:")
+    print(f"{'Language':<7} | {'Cycles':>15} | {'Time(s)':>10}")
+    print("-" * 42)
+    for lang in ['C', 'C++', 'Rust', 'Go', 'Python', 'Node', 'Java']:
+        info = results.get(lang, {})
+        cycles = info.get('cycles', 'N/A')
+        time_val = info.get('time', 'N/A')
+        print(f"{lang:<7} | {cycles:>15} | {time_val:>10}")
+
+
+def main():
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 1000000
+    print(f"Building programs...")
+    build_all()
+    print(f"Running with n={n}...\n")
+    results, outputs = run_programs(n)
+    for lang, out in outputs.items():
+        print(f"{lang}: {out}")
+    print_table(results)
+
+
+if __name__ == '__main__':
+    main()

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "rust_app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,0 +1,26 @@
+use std::env;
+use std::arch::x86_64::_rdtsc;
+use std::time::Instant;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let n: u64 = if args.len() > 1 {
+        args[1].parse().unwrap_or(1_000_000)
+    } else {
+        1_000_000
+    };
+    let wall_start = Instant::now();
+    let start = unsafe { _rdtsc() };
+    let mut sum_len: u64 = 0;
+    let mut dummy: u64 = 0;
+    for i in 0..n {
+        let mut x = i * 3 + 7;
+        x = (x ^ (x << 2)) + (x >> 3);
+        let s = x.to_string();
+        sum_len += s.len() as u64;
+        dummy = dummy.wrapping_add(x);
+    }
+    let end = unsafe { _rdtsc() };
+    let elapsed = wall_start.elapsed().as_secs_f64();
+    println!("sum={} dummy={} cycles={} time={}", sum_len, dummy, end - start, elapsed);
+}


### PR DESCRIPTION
## Summary
- include wall-clock timing in each benchmark implementation
- parse cycle count and time in the helper script
- document that `run_benchmarks.py` reports execution time as well

## Testing
- `gcc -O2 c/time_test.c -o c/time_test`
- `./c/time_test 1000`
- `g++ -O2 cpp/time_test.cpp -o cpp/time_test`
- `./cpp/time_test 1000`
- `cargo build --release` in rust
- `./rust/target/release/rust_app 1000`
- `CGO_ENABLED=1 go build -o go/time_test go/main.go`
- `./go/time_test 1000`
- `python3 python/main.py 1000`
- `node node/main.js 1000`
- `javac java/TimeTest.java`
- `java -cp java TimeTest 1000`
- `python3 run_benchmarks.py 1000`


------
https://chatgpt.com/codex/tasks/task_e_686671d570c8832dace353332abb788e