### PR TITLE
Add standalone sieve benchmark suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,90 @@
-# banchmark-langs
+# Benchmark Languages
+
+This repository provides small CLI programs in multiple languages that
+perform an identical, moderately complex workload while measuring both CPU
+cycles and wall-clock time consumed.  The programs manipulate integers and strings in a loop so
+the compiler cannot optimise the entire computation away.  They are intended
+for comparing performance across languages on Linux/WSL.
+
+## Languages Included
+
+- C
+- C++
+- Rust
+- Go
+- Python
+- JavaScript (Node.js)
+- Java
+
+## Installing Compilers/Interpreters
+
+On Ubuntu you can install the required tools with:
+
+```bash
+sudo apt-get update
+sudo apt-get install build-essential golang rustc cargo python3 nodejs default-jdk
+```
+
+## Build and Run
+
+### C
+
+```bash
+gcc -O2 c/time_test.c -o c/time_test
+./c/time_test 1000000
+```
+
+### C++
+
+```bash
+g++ -O2 cpp/time_test.cpp -o cpp/time_test
+./cpp/time_test 1000000
+```
+
+### Rust
+
+```bash
+cd rust
+cargo build --release
+./target/release/rust_app 1000000
+```
+
+### Go
+
+```bash
+go build -o go/time_test go/main.go
+./go/time_test 1000000
+```
+
+### Python
+
+```bash
+python3 python/main.py 1000000
+```
+
+### Node.js
+
+```bash
+node node/main.js 1000000
+```
+
+### Java
+
+```bash
+javac java/TimeTest.java
+java -cp java TimeTest 1000000
+```
+
+You can change the numeric argument to adjust the workload for your benchmark.
+
+### Run all benchmarks
+
+The helper script `run_benchmarks.py` builds and runs each implementation in
+sequence. Provide the desired iteration count as an argument:
+
+```bash
+python3 run_benchmarks.py 1000000
+```
+
+The script prints the output from each language and a table summarizing the
+cycle counts and execution times.

--- a/c/time_test.c
+++ b/c/time_test.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <x86intrin.h>
+#include <time.h>
+
+int main(int argc, char *argv[]) {
+    long long n = 1000000;
+    if (argc > 1) {
+        n = atoll(argv[1]);
+    }
+    struct timespec ts_start, ts_end;
+    clock_gettime(CLOCK_MONOTONIC, &ts_start);
+    unsigned long long start = __rdtsc();
+    long long sum_len = 0;
+    long long dummy = 0;
+    char buf[32];
+    for (long long i = 0; i < n; ++i) {
+        long long x = i * 3 + 7;
+        x = (x ^ (x << 2)) + (x >> 3);
+        snprintf(buf, sizeof(buf), "%lld", x);
+        sum_len += strlen(buf);
+        dummy += x;
+    }
+    unsigned long long end = __rdtsc();
+    clock_gettime(CLOCK_MONOTONIC, &ts_end);
+    double elapsed = (ts_end.tv_sec - ts_start.tv_sec) +
+                     (ts_end.tv_nsec - ts_start.tv_nsec) / 1e9;
+    printf("sum=%lld dummy=%lld cycles=%llu time=%f\n",
+           sum_len, dummy, end - start, elapsed);
+    return 0;
+}

--- a/cpp/time_test.cpp
+++ b/cpp/time_test.cpp
@@ -1,0 +1,28 @@
+#include <chrono>
+#include <iostream>
+#include <x86intrin.h>
+
+int main(int argc, char* argv[]) {
+    long long n = 1000000;
+    if (argc > 1) {
+        n = std::stoll(argv[1]);
+    }
+    auto wall_start = std::chrono::high_resolution_clock::now();
+    unsigned long long start = __rdtsc();
+    long long sum_len = 0;
+    long long dummy = 0;
+    for (long long i = 0; i < n; ++i) {
+        long long x = i * 3 + 7;
+        x = (x ^ (x << 2)) + (x >> 3);
+        std::string s = std::to_string(x);
+        sum_len += s.size();
+        dummy += x;
+    }
+    unsigned long long end = __rdtsc();
+    auto wall_end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = wall_end - wall_start;
+    std::cout << "sum=" << sum_len << " dummy=" << dummy
+              << " cycles=" << end - start
+              << " time=" << elapsed.count() << std::endl;
+    return 0;
+}

--- a/go/main.go
+++ b/go/main.go
@@ -1,0 +1,37 @@
+package main
+
+/*
+#include <x86intrin.h>
+unsigned long long read_cycles() { return __rdtsc(); }
+*/
+import "C"
+
+import (
+    "fmt"
+    "os"
+    "strconv"
+    "time"
+)
+
+func main() {
+    n := int64(1000000)
+    if len(os.Args) > 1 {
+        if val, err := strconv.ParseInt(os.Args[1], 10, 64); err == nil {
+            n = val
+        }
+    }
+    startWall := time.Now()
+    start := C.read_cycles()
+    sumLen := int64(0)
+    dummy := int64(0)
+    for i := int64(0); i < n; i++ {
+        x := i*3 + 7
+        x = (x ^ (x << 2)) + (x >> 3)
+        s := fmt.Sprintf("%d", x)
+        sumLen += int64(len(s))
+        dummy += x
+    }
+    end := C.read_cycles()
+    elapsed := time.Since(startWall).Seconds()
+    fmt.Printf("sum=%d dummy=%d cycles=%d time=%f\n", sumLen, dummy, end-start, elapsed)
+}

--- a/java/TimeTest.java
+++ b/java/TimeTest.java
@@ -1,0 +1,44 @@
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+
+public class TimeTest {
+
+    private static long cpuFreq() {
+        try (BufferedReader br = new BufferedReader(new FileReader("/proc/cpuinfo"))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.startsWith("cpu MHz")) {
+                    String[] parts = line.split(":");
+                    return (long) (Double.parseDouble(parts[1].trim()) * 1_000_000L);
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return 1_000_000_000L;
+    }
+
+    public static void main(String[] args) {
+        long n = 1_000_000;
+        if (args.length > 0) {
+            try {
+                n = Long.parseLong(args[0]);
+            } catch (NumberFormatException ignored) {}
+        }
+        long freq = cpuFreq();
+        long start = System.nanoTime();
+        long sumLen = 0;
+        long dummy = 0;
+        for (long i = 0; i < n; i++) {
+            long x = i * 3 + 7;
+            x = (x ^ (x << 2)) + (x >> 3);
+            String s = Long.toString(x);
+            sumLen += s.length();
+            dummy += x;
+        }
+        long elapsedNs = System.nanoTime() - start;
+        long cycles = (elapsedNs * freq) / 1_000_000_000L;
+        double timeSec = elapsedNs / 1_000_000_000.0;
+        System.out.println("sum=" + sumLen + " dummy=" + dummy + " cycles=" + cycles + " time=" + timeSec);
+    }
+}

--- a/node/main.js
+++ b/node/main.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+
+function cpuFreq() {
+  try {
+    const txt = fs.readFileSync('/proc/cpuinfo', 'utf8');
+    const m = txt.match(/cpu MHz\s+:\s+([0-9.]+)/);
+    if (m) return parseFloat(m[1]) * 1e6;
+  } catch (e) {}
+  return 1e9;
+}
+
+const n = process.argv[2] ? parseInt(process.argv[2], 10) : 1000000;
+const freq = cpuFreq();
+const start = process.hrtime.bigint();
+let sumLen = 0;
+let dummy = 0;
+for (let i = 0; i < n; i++) {
+  let x = i * 3 + 7;
+  x = (x ^ (x << 2)) + (x >> 3);
+  const s = String(x);
+  sumLen += s.length;
+  dummy += x;
+}
+const elapsedNs = process.hrtime.bigint() - start;
+const cycles = Math.round(Number(elapsedNs) * freq / 1e9);
+const timeSec = Number(elapsedNs) / 1e9;
+console.log(`sum=${sumLen} dummy=${dummy} cycles=${cycles} time=${timeSec}`);

--- a/primes_benchmark/Prime.java
+++ b/primes_benchmark/Prime.java
@@ -1,0 +1,18 @@
+public class Prime {
+    public static void main(String[] args) {
+        if (args.length < 1) return;
+        int n = Integer.parseInt(args[0]);
+        boolean[] isPrime = new boolean[n + 1];
+        for (int i = 2; i <= n; i++) isPrime[i] = true;
+        long start = System.nanoTime();
+        for (int p = 2; p * p <= n; p++) {
+            if (isPrime[p]) {
+                for (int j = p * p; j <= n; j += p) isPrime[j] = false;
+            }
+        }
+        int count = 0;
+        for (int i = 2; i <= n; i++) if (isPrime[i]) count++;
+        double elapsed = (System.nanoTime() - start) / 1e9;
+        System.out.printf("primes=%d time=%.6f\n", count, elapsed);
+    }
+}

--- a/primes_benchmark/README.txt
+++ b/primes_benchmark/README.txt
@@ -1,0 +1,68 @@
+Sieve Benchmark Suite
+=====================
+
+This directory contains CLI implementations of the Sieve of Eratosthenes in
+several languages and scripts to benchmark them on Linux/WSL.
+
+Requirements
+------------
+Install compilers/interpreters with:
+
+```
+sudo apt-get update
+sudo apt-get install build-essential g++ gcc python3 default-jdk golang-go rustc nodejs
+```
+
+Install Python packages for analysis:
+
+```
+pip install pandas matplotlib
+```
+
+Building
+--------
+Compile each implementation using:
+
+```
+gcc prime.c -o prime_c
+g++ prime.cpp -o prime_cpp
+rustc -C opt-level=3 prime.rs -o prime_rs
+go build -o prime_go prime.go
+javac Prime.java
+```
+
+Running the Benchmark
+---------------------
+Execute all programs with the same upper bound (default 10,000,000):
+
+```
+./run_benchmark.sh [N]
+```
+
+The script stores output from each run, including `/usr/bin/time -v` statistics,
+in `results.txt`.
+
+Analyzing Results
+-----------------
+Create a summary CSV:
+
+```
+python3 summarize_results.py
+```
+
+Generate charts:
+
+```
+python3 plot_benchmark.py
+python3 plot_memory_cpu.py
+```
+
+Packaging
+---------
+To create a tarball of this directory:
+
+```
+tar -czf primes_benchmark.tar.gz primes_benchmark
+```
+
+The tarball includes all sources, scripts, and this README.

--- a/primes_benchmark/plot_benchmark.py
+++ b/primes_benchmark/plot_benchmark.py
@@ -1,0 +1,11 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+
+df = pd.read_csv('benchmark_summary.csv')
+plt.figure(figsize=(8,4))
+plt.bar(df['Language'], df['Time (s)'])
+plt.ylabel('Time (s)')
+plt.title('Execution Time by Language')
+plt.tight_layout()
+plt.savefig('benchmark_chart.png')
+print('Saved benchmark_chart.png')

--- a/primes_benchmark/plot_memory_cpu.py
+++ b/primes_benchmark/plot_memory_cpu.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+
+df = pd.read_csv('benchmark_summary.csv')
+
+plt.figure(figsize=(8,4))
+plt.bar(df['Language'], df['Memory (KB)'])
+plt.ylabel('Memory (KB)')
+plt.title('Memory Usage by Language')
+plt.tight_layout()
+plt.savefig('memory_chart.png')
+print('Saved memory_chart.png')
+
+plt.figure(figsize=(8,4))
+plt.bar(df['Language'], df['CPU (%)'])
+plt.ylabel('CPU (%)')
+plt.title('CPU Percentage by Language')
+plt.tight_layout()
+plt.savefig('cpu_chart.png')
+print('Saved cpu_chart.png')

--- a/primes_benchmark/prime.c
+++ b/primes_benchmark/prime.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) return 1;
+    long n = atol(argv[1]);
+    char *is_prime = calloc(n + 1, sizeof(char));
+    if (!is_prime) return 1;
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    for (long i = 2; i <= n; i++) is_prime[i] = 1;
+    for (long p = 2; p * p <= n; p++) {
+        if (is_prime[p]) {
+            for (long j = p * p; j <= n; j += p) is_prime[j] = 0;
+        }
+    }
+    long count = 0;
+    for (long i = 2; i <= n; i++) if (is_prime[i]) count++;
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    double elapsed = (end.tv_sec - start.tv_sec) +
+                     (end.tv_nsec - start.tv_nsec) / 1e9;
+    printf("primes=%ld time=%.6f\n", count, elapsed);
+    free(is_prime);
+    return 0;
+}

--- a/primes_benchmark/prime.cpp
+++ b/primes_benchmark/prime.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <vector>
+#include <chrono>
+#include <iomanip>
+
+int main(int argc, char* argv[]) {
+    if (argc < 2) return 1;
+    long n = std::stol(argv[1]);
+    std::vector<bool> is_prime(n + 1, true);
+    auto start = std::chrono::high_resolution_clock::now();
+    for (long p = 2; p * p <= n; ++p) {
+        if (is_prime[p]) {
+            for (long j = p * p; j <= n; j += p) is_prime[j] = false;
+        }
+    }
+    long count = 0;
+    for (long i = 2; i <= n; ++i) if (is_prime[i]) ++count;
+    auto end = std::chrono::high_resolution_clock::now();
+    double elapsed = std::chrono::duration<double>(end - start).count();
+    std::cout << "primes=" << count << " time=" << std::fixed << std::setprecision(6) << elapsed << "\n";
+    return 0;
+}

--- a/primes_benchmark/prime.go
+++ b/primes_benchmark/prime.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+    "fmt"
+    "os"
+    "strconv"
+    "time"
+)
+
+func main() {
+    if len(os.Args) < 2 {
+        return
+    }
+    n, _ := strconv.Atoi(os.Args[1])
+    isPrime := make([]bool, n+1)
+    for i := 2; i <= n; i++ {
+        isPrime[i] = true
+    }
+    start := time.Now()
+    for p := 2; p*p <= n; p++ {
+        if isPrime[p] {
+            for j := p * p; j <= n; j += p {
+                isPrime[j] = false
+            }
+        }
+    }
+    count := 0
+    for i := 2; i <= n; i++ {
+        if isPrime[i] {
+            count++
+        }
+    }
+    elapsed := time.Since(start).Seconds()
+    fmt.Printf("primes=%d time=%.6f\n", count, elapsed)
+}

--- a/primes_benchmark/prime.js
+++ b/primes_benchmark/prime.js
@@ -1,0 +1,18 @@
+const n = parseInt(process.argv[2]);
+if (!n) process.exit(1);
+const isPrime = Array(n + 1).fill(true);
+const start = process.hrtime.bigint();
+for (let p = 2; p * p <= n; p++) {
+  if (isPrime[p]) {
+    for (let j = p * p; j <= n; j += p) {
+      isPrime[j] = false;
+    }
+  }
+}
+let count = 0;
+for (let i = 2; i <= n; i++) {
+  if (isPrime[i]) count++;
+}
+const end = process.hrtime.bigint();
+const elapsed = Number(end - start) / 1e9;
+console.log(`primes=${count} time=${elapsed.toFixed(6)}`);

--- a/primes_benchmark/prime.py
+++ b/primes_benchmark/prime.py
@@ -1,0 +1,22 @@
+import sys
+import time
+
+def sieve(n):
+    is_prime = [True] * (n + 1)
+    for i in range(2, int(n ** 0.5) + 1):
+        if is_prime[i]:
+            for j in range(i * i, n + 1, i):
+                is_prime[j] = False
+    return sum(1 for i in range(2, n + 1) if is_prime[i])
+
+def main():
+    if len(sys.argv) < 2:
+        return
+    n = int(sys.argv[1])
+    start = time.time()
+    count = sieve(n)
+    elapsed = time.time() - start
+    print(f"primes={count} time={elapsed:.6f}")
+
+if __name__ == "__main__":
+    main()

--- a/primes_benchmark/prime.rs
+++ b/primes_benchmark/prime.rs
@@ -1,0 +1,29 @@
+use std::env;
+use std::hint::black_box;
+use std::time::Instant;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 { return; }
+    let n: usize = args[1].parse().unwrap();
+    let mut is_prime = vec![true; n + 1];
+    let start = Instant::now();
+    let mut p = 2usize;
+    while p * p <= n {
+        if is_prime[p] {
+            let mut j = p * p;
+            while j <= n {
+                is_prime[j] = false;
+                j += p;
+            }
+        }
+        p += 1;
+    }
+    let mut count = 0usize;
+    for i in 2..=n {
+        if is_prime[i] { count += 1; }
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+    black_box(count);
+    println!("primes={} time={:.6}", count, elapsed);
+}

--- a/primes_benchmark/run_benchmark.sh
+++ b/primes_benchmark/run_benchmark.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+N=${1:-10000000}
+rm -f results.txt
+
+compile_and_run() {
+  local lang=$1
+  shift
+  echo "=== $lang ===" >> results.txt
+  /usr/bin/time -v "$@" $N >> results.txt 2>&1
+  echo >> results.txt
+}
+
+# C
+gcc prime.c -O2 -o prime_c
+compile_and_run "C" ./prime_c
+
+# C++
+g++ prime.cpp -O2 -o prime_cpp
+compile_and_run "C++" ./prime_cpp
+
+# Rust
+rustc -C opt-level=3 prime.rs -o prime_rs
+compile_and_run "Rust" ./prime_rs
+
+# Go
+go build -o prime_go prime.go
+compile_and_run "Go" ./prime_go
+
+# Python
+compile_and_run "Python" python3 prime.py
+
+# Java
+javac Prime.java
+compile_and_run "Java" java Prime
+
+# Node
+compile_and_run "Node" node prime.js

--- a/primes_benchmark/summarize_results.py
+++ b/primes_benchmark/summarize_results.py
@@ -1,0 +1,37 @@
+import csv
+import re
+
+records = []
+record = {}
+with open('results.txt') as f:
+    for line in f:
+        line = line.strip()
+        header = re.match(r'^===\s*(.+?)\s*===$', line)
+        if header:
+            if record:
+                records.append(record)
+                record = {}
+            record['Language'] = header.group(1)
+        elif line.startswith('primes='):
+            m = re.search(r'primes=(\d+)\s+time=([0-9.]+)', line)
+            if m:
+                record['Primes'] = int(m.group(1))
+                record['Time (s)'] = float(m.group(2))
+        elif 'User time (seconds):' in line:
+            record['User time (s)'] = float(line.split(':')[1].strip())
+        elif 'System time (seconds):' in line:
+            record['System time (s)'] = float(line.split(':')[1].strip())
+        elif 'Percent of CPU this job got:' in line:
+            record['CPU (%)'] = float(line.split(':')[1].strip().replace('%',''))
+        elif line.startswith('Maximum resident set size'):
+            record['Memory (KB)'] = int(line.split(':')[1].strip())
+
+if record:
+    records.append(record)
+
+with open('benchmark_summary.csv', 'w', newline='') as f:
+    writer = csv.DictWriter(f, fieldnames=['Language','Primes','Time (s)','User time (s)','System time (s)','CPU (%)','Memory (KB)'])
+    writer.writeheader()
+    for r in records:
+        writer.writerow(r)
+print('Wrote benchmark_summary.csv')

--- a/python/main.py
+++ b/python/main.py
@@ -1,0 +1,29 @@
+import sys
+import time
+
+
+def cpu_freq():
+    try:
+        with open('/proc/cpuinfo') as f:
+            for line in f:
+                if line.startswith('cpu MHz'):
+                    return float(line.split(':')[1]) * 1e6
+    except FileNotFoundError:
+        pass
+    return 1e9
+
+
+n = int(sys.argv[1]) if len(sys.argv) > 1 else 1_000_000
+freq = cpu_freq()
+start = time.perf_counter()
+sum_len = 0
+dummy = 0
+for i in range(n):
+    x = i * 3 + 7
+    x = (x ^ (x << 2)) + (x >> 3)
+    s = str(x)
+    sum_len += len(s)
+    dummy += x
+elapsed = time.perf_counter() - start
+cycles = int(elapsed * freq)
+print(f"sum={sum_len} dummy={dummy} cycles={cycles} time={elapsed}")

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import re
+from pathlib import Path
+import os
+
+ROOT = Path(__file__).resolve().parent
+
+# compile all languages
+
+def run(cmd, cwd=None, env=None):
+    result = subprocess.run(cmd, shell=True, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    if result.stdout:
+        print(result.stdout)
+    return result
+
+def build_all():
+    run("gcc -O2 time_test.c -o time_test", cwd=ROOT / 'c')
+    run("g++ -O2 time_test.cpp -o time_test", cwd=ROOT / 'cpp')
+    run("cargo build --release", cwd=ROOT / 'rust')
+    env = os.environ.copy()
+    env['CGO_ENABLED'] = '1'
+    run("go build -o time_test main.go", cwd=ROOT / 'go', env=env)
+    run("javac TimeTest.java", cwd=ROOT / 'java')
+
+
+def capture_output(cmd, cwd=None):
+    result = subprocess.run(cmd, shell=True, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    return result.stdout.strip()
+
+
+def run_programs(n):
+    results = {}
+    outputs = {}
+    outputs['C'] = capture_output(f"./time_test {n}", cwd=ROOT / 'c')
+    outputs['C++'] = capture_output(f"./time_test {n}", cwd=ROOT / 'cpp')
+    outputs['Rust'] = capture_output(f"./target/release/rust_app {n}", cwd=ROOT / 'rust')
+    outputs['Go'] = capture_output(f"./time_test {n}", cwd=ROOT / 'go')
+    outputs['Python'] = capture_output(f"python3 main.py {n}", cwd=ROOT / 'python')
+    outputs['Node'] = capture_output(f"node main.js {n}", cwd=ROOT / 'node')
+    outputs['Java'] = capture_output(f"java TimeTest {n}", cwd=ROOT / 'java')
+
+    for lang, out in outputs.items():
+        m_cycles = re.search(r'cycles=([0-9]+)', out)
+        m_time = re.search(r'time=([0-9.eE+-]+)', out)
+        results[lang] = {
+            'cycles': m_cycles.group(1) if m_cycles else 'N/A',
+            'time': m_time.group(1) if m_time else 'N/A'
+        }
+    return results, outputs
+
+
+def print_table(results):
+    print("\nResults:")
+    print(f"{'Language':<7} | {'Cycles':>15} | {'Time(s)':>10}")
+    print("-" * 42)
+    for lang in ['C', 'C++', 'Rust', 'Go', 'Python', 'Node', 'Java']:
+        info = results.get(lang, {})
+        cycles = info.get('cycles', 'N/A')
+        time_val = info.get('time', 'N/A')
+        print(f"{lang:<7} | {cycles:>15} | {time_val:>10}")
+
+
+def main():
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 1000000
+    print(f"Building programs...")
+    build_all()
+    print(f"Running with n={n}...\n")
+    results, outputs = run_programs(n)
+    for lang, out in outputs.items():
+        print(f"{lang}: {out}")
+    print_table(results)
+
+
+if __name__ == '__main__':
+    main()

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "rust_app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,0 +1,26 @@
+use std::env;
+use std::arch::x86_64::_rdtsc;
+use std::time::Instant;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let n: u64 = if args.len() > 1 {
+        args[1].parse().unwrap_or(1_000_000)
+    } else {
+        1_000_000
+    };
+    let wall_start = Instant::now();
+    let start = unsafe { _rdtsc() };
+    let mut sum_len: u64 = 0;
+    let mut dummy: u64 = 0;
+    for i in 0..n {
+        let mut x = i * 3 + 7;
+        x = (x ^ (x << 2)) + (x >> 3);
+        let s = x.to_string();
+        sum_len += s.len() as u64;
+        dummy = dummy.wrapping_add(x);
+    }
+    let end = unsafe { _rdtsc() };
+    let elapsed = wall_start.elapsed().as_secs_f64();
+    println!("sum={} dummy={} cycles={} time={}", sum_len, dummy, end - start, elapsed);
+}

--- a/sieve_benchmark/Prime.java
+++ b/sieve_benchmark/Prime.java
@@ -1,0 +1,18 @@
+public class Prime {
+    public static void main(String[] args) {
+        if (args.length < 1) return;
+        int n = Integer.parseInt(args[0]);
+        boolean[] isPrime = new boolean[n + 1];
+        for (int i = 2; i <= n; i++) isPrime[i] = true;
+        long start = System.nanoTime();
+        for (int p = 2; p * p <= n; p++) {
+            if (isPrime[p]) {
+                for (int j = p * p; j <= n; j += p) isPrime[j] = false;
+            }
+        }
+        int count = 0;
+        for (int i = 2; i <= n; i++) if (isPrime[i]) count++;
+        double elapsed = (System.nanoTime() - start) / 1e9;
+        System.out.printf("primes=%d time=%.6f\n", count, elapsed);
+    }
+}

--- a/sieve_benchmark/README.txt
+++ b/sieve_benchmark/README.txt
@@ -1,0 +1,58 @@
+Sieve Benchmark Suite
+=====================
+
+This directory contains CLI implementations of the Sieve of Eratosthenes in
+several languages and scripts to benchmark them on Linux/WSL.
+
+Requirements
+------------
+Install compilers/interpreters with:
+
+```
+sudo apt-get update
+sudo apt-get install build-essential g++ gcc python3 default-jdk golang-go rustc nodejs
+```
+
+Install Python packages for analysis:
+
+```
+pip install pandas matplotlib
+```
+
+Building
+--------
+Compile each implementation using:
+
+```
+gcc prime.c -o prime_c
+g++ prime.cpp -o prime_cpp
+rustc -C opt-level=3 prime.rs -o prime_rs
+go build -o prime_go prime.go
+javac Prime.java
+```
+
+Running the Benchmark
+---------------------
+Execute all programs with the same upper bound (default 10,000,000):
+
+```
+./run_benchmark.sh [N]
+```
+
+The script stores output from each run, including `/usr/bin/time -v` statistics,
+in `results.txt`.
+
+Analyzing Results
+-----------------
+Create a summary CSV:
+
+```
+python3 summarize_results.py
+```
+
+Generate charts:
+
+```
+python3 plot_benchmark.py
+python3 plot_memory_cpu.py
+```

--- a/sieve_benchmark/plot_benchmark.py
+++ b/sieve_benchmark/plot_benchmark.py
@@ -1,0 +1,11 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+
+df = pd.read_csv('benchmark_summary.csv')
+plt.figure(figsize=(8,4))
+plt.bar(df['Language'], df['Time (s)'])
+plt.ylabel('Time (s)')
+plt.title('Execution Time by Language')
+plt.tight_layout()
+plt.savefig('benchmark_chart.png')
+print('Saved benchmark_chart.png')

--- a/sieve_benchmark/plot_memory_cpu.py
+++ b/sieve_benchmark/plot_memory_cpu.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+
+df = pd.read_csv('benchmark_summary.csv')
+
+plt.figure(figsize=(8,4))
+plt.bar(df['Language'], df['Memory (KB)'])
+plt.ylabel('Memory (KB)')
+plt.title('Memory Usage by Language')
+plt.tight_layout()
+plt.savefig('memory_chart.png')
+print('Saved memory_chart.png')
+
+plt.figure(figsize=(8,4))
+plt.bar(df['Language'], df['CPU (%)'])
+plt.ylabel('CPU (%)')
+plt.title('CPU Percentage by Language')
+plt.tight_layout()
+plt.savefig('cpu_chart.png')
+print('Saved cpu_chart.png')

--- a/sieve_benchmark/prime.c
+++ b/sieve_benchmark/prime.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) return 1;
+    long n = atol(argv[1]);
+    char *is_prime = calloc(n + 1, sizeof(char));
+    if (!is_prime) return 1;
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    for (long i = 2; i <= n; i++) is_prime[i] = 1;
+    for (long p = 2; p * p <= n; p++) {
+        if (is_prime[p]) {
+            for (long j = p * p; j <= n; j += p) is_prime[j] = 0;
+        }
+    }
+    long count = 0;
+    for (long i = 2; i <= n; i++) if (is_prime[i]) count++;
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    double elapsed = (end.tv_sec - start.tv_sec) +
+                     (end.tv_nsec - start.tv_nsec) / 1e9;
+    printf("primes=%ld time=%.6f\n", count, elapsed);
+    free(is_prime);
+    return 0;
+}

--- a/sieve_benchmark/prime.cpp
+++ b/sieve_benchmark/prime.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <vector>
+#include <chrono>
+#include <iomanip>
+
+int main(int argc, char* argv[]) {
+    if (argc < 2) return 1;
+    long n = std::stol(argv[1]);
+    std::vector<bool> is_prime(n + 1, true);
+    auto start = std::chrono::high_resolution_clock::now();
+    for (long p = 2; p * p <= n; ++p) {
+        if (is_prime[p]) {
+            for (long j = p * p; j <= n; j += p) is_prime[j] = false;
+        }
+    }
+    long count = 0;
+    for (long i = 2; i <= n; ++i) if (is_prime[i]) ++count;
+    auto end = std::chrono::high_resolution_clock::now();
+    double elapsed = std::chrono::duration<double>(end - start).count();
+    std::cout << "primes=" << count << " time=" << std::fixed << std::setprecision(6) << elapsed << "\n";
+    return 0;
+}

--- a/sieve_benchmark/prime.go
+++ b/sieve_benchmark/prime.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+    "fmt"
+    "os"
+    "strconv"
+    "time"
+)
+
+func main() {
+    if len(os.Args) < 2 {
+        return
+    }
+    n, _ := strconv.Atoi(os.Args[1])
+    isPrime := make([]bool, n+1)
+    for i := 2; i <= n; i++ {
+        isPrime[i] = true
+    }
+    start := time.Now()
+    for p := 2; p*p <= n; p++ {
+        if isPrime[p] {
+            for j := p * p; j <= n; j += p {
+                isPrime[j] = false
+            }
+        }
+    }
+    count := 0
+    for i := 2; i <= n; i++ {
+        if isPrime[i] {
+            count++
+        }
+    }
+    elapsed := time.Since(start).Seconds()
+    fmt.Printf("primes=%d time=%.6f\n", count, elapsed)
+}

--- a/sieve_benchmark/prime.js
+++ b/sieve_benchmark/prime.js
@@ -1,0 +1,18 @@
+const n = parseInt(process.argv[2]);
+if (!n) process.exit(1);
+const isPrime = Array(n + 1).fill(true);
+const start = process.hrtime.bigint();
+for (let p = 2; p * p <= n; p++) {
+  if (isPrime[p]) {
+    for (let j = p * p; j <= n; j += p) {
+      isPrime[j] = false;
+    }
+  }
+}
+let count = 0;
+for (let i = 2; i <= n; i++) {
+  if (isPrime[i]) count++;
+}
+const end = process.hrtime.bigint();
+const elapsed = Number(end - start) / 1e9;
+console.log(`primes=${count} time=${elapsed.toFixed(6)}`);

--- a/sieve_benchmark/prime.py
+++ b/sieve_benchmark/prime.py
@@ -1,0 +1,22 @@
+import sys
+import time
+
+def sieve(n: int) -> int:
+    is_prime = [True] * (n + 1)
+    for i in range(2, int(n ** 0.5) + 1):
+        if is_prime[i]:
+            for j in range(i * i, n + 1, i):
+                is_prime[j] = False
+    return sum(1 for i in range(2, n + 1) if is_prime[i])
+
+def main():
+    if len(sys.argv) < 2:
+        return
+    n = int(sys.argv[1])
+    start = time.time()
+    count = sieve(n)
+    elapsed = time.time() - start
+    print(f"primes={count} time={elapsed:.6f}")
+
+if __name__ == "__main__":
+    main()

--- a/sieve_benchmark/prime.rs
+++ b/sieve_benchmark/prime.rs
@@ -1,0 +1,26 @@
+use std::env;
+use std::time::Instant;
+use std::hint::black_box;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 { return; }
+    let n: usize = args[1].parse().unwrap();
+    let mut is_prime = vec![true; n + 1];
+    let start = Instant::now();
+    let mut p = 2usize;
+    while p * p <= n {
+        if is_prime[p] {
+            let mut j = p * p;
+            while j <= n {
+                is_prime[j] = false;
+                j += p;
+            }
+        }
+        p += 1;
+    }
+    let count = (2..=n).filter(|&i| is_prime[i]).count();
+    let elapsed = start.elapsed().as_secs_f64();
+    black_box(count);
+    println!("primes={} time={:.6}", count, elapsed);
+}

--- a/sieve_benchmark/run_benchmark.sh
+++ b/sieve_benchmark/run_benchmark.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+N=${1:-10000000}
+cd "$(dirname "$0")"
+rm -f results.txt
+
+run() {
+  local lang=$1
+  shift
+  echo "=== $lang ===" >> results.txt
+  /usr/bin/time -v "$@" $N >> results.txt 2>&1
+  echo >> results.txt
+}
+
+gcc prime.c -O2 -o prime_c
+run "C" ./prime_c
+
+g++ prime.cpp -O2 -o prime_cpp
+run "C++" ./prime_cpp
+
+rustc -C opt-level=3 prime.rs -o prime_rs
+run "Rust" ./prime_rs
+
+go build -o prime_go prime.go
+run "Go" ./prime_go
+
+run "Python" python3 prime.py
+
+javac Prime.java
+run "Java" java Prime
+
+run "Node" node prime.js

--- a/sieve_benchmark/summarize_results.py
+++ b/sieve_benchmark/summarize_results.py
@@ -1,0 +1,36 @@
+import csv
+import re
+
+records = []
+record = {}
+with open('results.txt') as f:
+    for line in f:
+        line = line.strip()
+        header = re.match(r'^===\s*(.+?)\s*===$', line)
+        if header:
+            if record:
+                records.append(record)
+                record = {}
+            record['Language'] = header.group(1)
+        elif line.startswith('primes='):
+            m = re.search(r'primes=(\d+)\s+time=([0-9.]+)', line)
+            if m:
+                record['Primes'] = int(m.group(1))
+                record['Time (s)'] = float(m.group(2))
+        elif 'User time (seconds):' in line:
+            record['User time (s)'] = float(line.split(':')[1].strip())
+        elif 'System time (seconds):' in line:
+            record['System time (s)'] = float(line.split(':')[1].strip())
+        elif 'Percent of CPU this job got:' in line:
+            record['CPU (%)'] = float(line.split(':')[1].strip().replace('%',''))
+        elif line.startswith('Maximum resident set size'):
+            record['Memory (KB)'] = int(line.split(':')[1].strip())
+if record:
+    records.append(record)
+
+with open('benchmark_summary.csv', 'w', newline='') as f:
+    writer = csv.DictWriter(f, fieldnames=['Language','Primes','Time (s)','User time (s)','System time (s)','CPU (%)','Memory (KB)'])
+    writer.writeheader()
+    for r in records:
+        writer.writerow(r)
+print('Wrote benchmark_summary.csv')


### PR DESCRIPTION
## Summary
- add `sieve_benchmark` with Sieve of Eratosthenes implementations in 7 languages
- provide `run_benchmark.sh` to compile programs and run them with `/usr/bin/time -v`
- include scripts to summarize and plot results
- document requirements and usage in `sieve_benchmark/README.txt`
- remove prior tarball

## Testing
- `gcc prime.c -o prime_c && ./prime_c 1000`
- `g++ prime.cpp -o prime_cpp && ./prime_cpp 1000`
- `rustc -C opt-level=3 prime.rs -o prime_rs && ./prime_rs 1000`
- `go build -o prime_go prime.go && ./prime_go 1000`
- `python3 prime.py 1000`
- `javac Prime.java && java Prime 1000`
- `node prime.js 1000`
- `./run_benchmark.sh 1000` *(failed: `/usr/bin/time` not found)*
- `python3 summarize_results.py`
- `python3 plot_benchmark.py` *(failed: `pandas` missing)*
- `python3 plot_memory_cpu.py` *(failed: `pandas` missing)*


------
https://chatgpt.com/codex/tasks/task_e_686671d570c8832dace353332abb788e